### PR TITLE
CC-34725 Introduce the ConfigurableBundleService::expandConfiguredBundleWithGroupKey() method.

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -1,4 +1,6 @@
 namespace: SprykerTest
+include:
+  - tests/SprykerTest/Service/ConfigurableBundle
 
 paths:
   tests: tests

--- a/dependency.json
+++ b/dependency.json
@@ -1,5 +1,6 @@
 {
   "include": {
-    "UuidBehavior": "Used to generate UUIDs for entities."
+    "spryker/uuid-behavior": "Used to generate UUIDs for entities.",
+    "spryker/transfer": "Provides transfer objects definition with `::get*OrFail()` functionality."
   }
 }

--- a/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleDependencyProvider.php
+++ b/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleDependencyProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\ConfigurableBundle;
+
+use Spryker\Service\Kernel\AbstractBundleDependencyProvider;
+
+class ConfigurableBundleDependencyProvider extends AbstractBundleDependencyProvider
+{
+}

--- a/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleFactory.php
+++ b/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\ConfigurableBundle;
+
+use Spryker\Service\ConfigurableBundle\Expander\ConfiguredBundleGroupKeyExpander;
+use Spryker\Service\ConfigurableBundle\Expander\ConfiguredBundleGroupKeyExpanderInterface;
+use Spryker\Service\Kernel\AbstractServiceFactory;
+
+class ConfigurableBundleFactory extends AbstractServiceFactory
+{
+    /**
+     * @return \Spryker\Service\ConfigurableBundle\Expander\ConfiguredBundleGroupKeyExpanderInterface
+     */
+    public function createConfiguredBundleGroupKeyExpander(): ConfiguredBundleGroupKeyExpanderInterface
+    {
+        return new ConfiguredBundleGroupKeyExpander();
+    }
+}

--- a/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleService.php
+++ b/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleService.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\ConfigurableBundle;
+
+use Generated\Shared\Transfer\ConfiguredBundleTransfer;
+use Spryker\Service\Kernel\AbstractService;
+
+/**
+ * @method \Spryker\Service\ConfigurableBundle\ConfigurableBundleFactory getFactory()
+ */
+class ConfigurableBundleService extends AbstractService implements ConfigurableBundleServiceInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ConfiguredBundleTransfer $configuredBundleTransfer
+     *
+     * @return \Generated\Shared\Transfer\ConfiguredBundleTransfer
+     */
+    public function expandConfiguredBundleWithGroupKey(ConfiguredBundleTransfer $configuredBundleTransfer): ConfiguredBundleTransfer
+    {
+        return $this->getFactory()
+            ->createConfiguredBundleGroupKeyExpander()
+            ->expandConfiguredBundleWithGroupKey($configuredBundleTransfer);
+    }
+}

--- a/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleServiceInterface.php
+++ b/src/Spryker/Service/ConfigurableBundle/ConfigurableBundleServiceInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\ConfigurableBundle;
+
+use Generated\Shared\Transfer\ConfiguredBundleTransfer;
+
+interface ConfigurableBundleServiceInterface
+{
+    /**
+     * Specification:
+     * - Requires `ConfiguredBundleTransfer.template` to be set.
+     * - Requires `ConfiguredBundleTransfer.template.uuid` to be set.
+     * - Generates the group key based on `ConfiguredBundleTransfer.template.uuid`.
+     * - Returns `ConfiguredBundleTransfer` expanded with the group key.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ConfiguredBundleTransfer $configuredBundleTransfer
+     *
+     * @return \Generated\Shared\Transfer\ConfiguredBundleTransfer
+     */
+    public function expandConfiguredBundleWithGroupKey(ConfiguredBundleTransfer $configuredBundleTransfer): ConfiguredBundleTransfer;
+}

--- a/src/Spryker/Service/ConfigurableBundle/Expander/ConfiguredBundleGroupKeyExpander.php
+++ b/src/Spryker/Service/ConfigurableBundle/Expander/ConfiguredBundleGroupKeyExpander.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\ConfigurableBundle\Expander;
+
+use Generated\Shared\Transfer\ConfiguredBundleTransfer;
+
+class ConfiguredBundleGroupKeyExpander implements ConfiguredBundleGroupKeyExpanderInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ConfiguredBundleTransfer $configuredBundleTransfer
+     *
+     * @return \Generated\Shared\Transfer\ConfiguredBundleTransfer
+     */
+    public function expandConfiguredBundleWithGroupKey(ConfiguredBundleTransfer $configuredBundleTransfer): ConfiguredBundleTransfer
+    {
+        $configuredBundleGroupKey = sprintf(
+            '%s-%s',
+            $configuredBundleTransfer->getTemplateOrFail()->getUuidOrFail(),
+            uniqid('', true)
+        );
+
+        return $configuredBundleTransfer->setGroupKey($configuredBundleGroupKey);
+    }
+}

--- a/src/Spryker/Service/ConfigurableBundle/Expander/ConfiguredBundleGroupKeyExpanderInterface.php
+++ b/src/Spryker/Service/ConfigurableBundle/Expander/ConfiguredBundleGroupKeyExpanderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\ConfigurableBundle\Expander;
+
+use Generated\Shared\Transfer\ConfiguredBundleTransfer;
+
+interface ConfiguredBundleGroupKeyExpanderInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ConfiguredBundleTransfer $configuredBundleTransfer
+     *
+     * @return \Generated\Shared\Transfer\ConfiguredBundleTransfer
+     */
+    public function expandConfiguredBundleWithGroupKey(ConfiguredBundleTransfer $configuredBundleTransfer): ConfiguredBundleTransfer;
+}

--- a/tests/SprykerTest/Service/ConfigurableBundle/ConfigurableBundleServiceTest.php
+++ b/tests/SprykerTest/Service/ConfigurableBundle/ConfigurableBundleServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Service\ConfigurableBundle;
+
+use Codeception\Test\Unit;
+use Generated\Shared\DataBuilder\ConfiguredBundleBuilder;
+use Generated\Shared\Transfer\ConfigurableBundleTemplateTransfer;
+use Generated\Shared\Transfer\ConfiguredBundleTransfer;
+use Spryker\Shared\Kernel\Transfer\Exception\NullValueException;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Service
+ * @group ConfigurableBundle
+ * @group ConfigurableBundleServiceTest
+ * Add your own group annotations below this line
+ */
+class ConfigurableBundleServiceTest extends Unit
+{
+    /**
+     * @var \SprykerTest\Service\ConfigurableBundle\ConfigurableBundleServiceTester
+     */
+    protected $tester;
+
+    /**
+     * @return void
+     */
+    public function testExpandConfiguredBundleWithGroupKeyAddsGroupKeyToConfiguredBundle(): void
+    {
+        // Arrange
+        $configuredBundleTransfer = (new ConfiguredBundleBuilder())
+            ->withTemplate([
+                ConfigurableBundleTemplateTransfer::UUID => 'configurable-bundle-template-uuid',
+            ])
+            ->build();
+
+        // Act
+        $resultConfiguredBundleTransfer = $this->tester->getService()
+            ->expandConfiguredBundleWithGroupKey($configuredBundleTransfer);
+
+        // Assert
+        $this->assertNotNull($resultConfiguredBundleTransfer->getGroupKey());
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpandConfiguredBundleWithGroupKeyThrowsExceptionWhenConfigurableBundleTemplateIsNotProvided(): void
+    {
+        // Arrange
+        $configuredBundleTransfer = (new ConfiguredBundleBuilder([
+            ConfiguredBundleTransfer::TEMPLATE => null,
+        ]))->build();
+
+        // Assert
+        $this->expectException(NullValueException::class);
+        $this->expectExceptionMessage(sprintf('Property "template" of transfer `%s` is null.', ConfiguredBundleTransfer::class));
+
+        // Act
+        $this->tester->getService()->expandConfiguredBundleWithGroupKey($configuredBundleTransfer);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpandConfiguredBundleWithGroupKeyThrowsExceptionWhenConfigurableBundleTemplateUuidIsNotProvided(): void
+    {
+        // Arrange
+        $configuredBundleTransfer = (new ConfiguredBundleBuilder())
+            ->withTemplate([ConfigurableBundleTemplateTransfer::UUID => null])
+            ->build();
+
+        // Assert
+        $this->expectException(NullValueException::class);
+        $this->expectExceptionMessage(sprintf('Property "uuid" of transfer `%s` is null.', ConfigurableBundleTemplateTransfer::class));
+
+        // Act
+        $this->tester->getService()->expandConfiguredBundleWithGroupKey($configuredBundleTransfer);
+    }
+}

--- a/tests/SprykerTest/Service/ConfigurableBundle/_support/ConfigurableBundleServiceTester.php
+++ b/tests/SprykerTest/Service/ConfigurableBundle/_support/ConfigurableBundleServiceTester.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Service\ConfigurableBundle;
+
+use Codeception\Actor;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantTo($text)
+ * @method void wantToTest($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ * @method \Spryker\Service\ConfigurableBundle\ConfigurableBundleServiceInterface getService(?string $moduleName = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class ConfigurableBundleServiceTester extends Actor
+{
+    use _generated\ConfigurableBundleServiceTesterActions;
+}

--- a/tests/SprykerTest/Service/ConfigurableBundle/codeception.yml
+++ b/tests/SprykerTest/Service/ConfigurableBundle/codeception.yml
@@ -1,0 +1,21 @@
+namespace: SprykerTest\Service\ConfigurableBundle
+
+paths:
+    tests: .
+    data: ../../../_data
+    support: _support
+    log: ../../../_output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Service:
+        path: .
+        class_name: ConfigurableBundleServiceTester
+        modules:
+            enabled:
+                - Asserts
+                - \SprykerTest\Service\Testify\Helper\ServiceHelper


### PR DESCRIPTION
- Developer(s): @AsonUnique

- Ticket: https://spryker.atlassian.net/browse/CC-34501

- Release Group: TBD

- strategy: major

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ConfigurableBundle    | minor                 |                       |

-----------------------------------------

#### Module ConfigurableBundle

##### Change log

Improvements

- Introduced `\Spryker\Service\ConfigurableBundle\ConfigurableBundleService::expandConfiguredBundleWithGroupKey()` to extend `ConfiguredBundleTransfer` with group key.

